### PR TITLE
c++11 doesn't compile, but c++14 does

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ server. Try `cd`ing to the directory containing the echo server at
 liner:
 
 <code>
-g++ -std=c++11 -o my_echo EchoServer.cpp EchoHandler.cpp -lproxygenhttpserver -lfolly -lglog -lgflags -pthread
+g++ -std=c++14 -o my_echo EchoServer.cpp EchoHandler.cpp -lproxygenhttpserver -lfolly -lglog -lgflags -pthread
 </code>
 
 After running `./my_echo`, we can verify it works using curl in a different terminal:


### PR DESCRIPTION
Fixes various errors of this form:

/usr/local/include/folly/Synchronized.h:396:41: error: 'withLockPtr' function uses 'auto' type specifier without trailing return type
   auto withLockPtr(Function&& function) const {
                                         ^
/usr/local/include/folly/Synchronized.h:396:41: note: deduced return type only available with -std=c++14 or -std=gnu++14